### PR TITLE
Update CachedDict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,14 @@ python:
   - "2.6"
   - "2.7"
 env:
-  - DJANGO=1.2.7
-  - DJANGO=1.3.1
   - DJANGO=1.4
+  - DJANGO=1.5
+  - DJANGO=1.6
+  - DJANGO=1.7
+matrix:
+  exclude:
+    - python: "2.6"
+      env: DJANGO=1.7
 install:
   - pip install -q Django==$DJANGO --use-mirrors
   - pip install pep8 --use-mirrors

--- a/modeldict/base.py
+++ b/modeldict/base.py
@@ -179,12 +179,11 @@ class CachedDict(object):
             # local_cache
             if local_cache_is_invalid or local_cache_is_invalid is None:
                 self._local_cache = self.remote_cache.get(self.remote_cache_key)
+                if self._local_cache:
+                    # We've updated from remote, so mark ourselves as such
+                    self._local_last_updated = now
 
-            # No matter what, we've updated from remote, so mark ourselves as
-            # such so that we won't expire until the next timeout
-            self._local_last_updated = now
-
-        # Update from cache if local_cache is still empty
+        # Update from source if local_cache is still empty
         if self._local_cache is None:
             self._update_cache_data()
 

--- a/tests/modeldict/__init__.py
+++ b/tests/modeldict/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'tests.modeldict.apps.ModelDictTestsConfig'

--- a/tests/modeldict/apps.py
+++ b/tests/modeldict/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class ModelDictTestsConfig(AppConfig):
+    name = 'tests.modeldict'
+    label = 'modeldict-tests'

--- a/tests/modeldict/tests.py
+++ b/tests/modeldict/tests.py
@@ -338,3 +338,25 @@ class CachedDictTest(TestCase):
             self.mydict.remote_cache_last_updated_key
         )
         self.assertEquals(result, True)
+
+    @mock.patch('modeldict.base.CachedDict.local_cache_has_expired')
+    @mock.patch('modeldict.base.CachedDict.local_cache_is_invalid')
+    def test_local_last_updated_value(self, invalid_mock, expired_mock):
+        """
+        We want local cache last updated value to be updated if and only if
+        a cache update actually took place.
+        """
+        self.mydict._local_cache = {}
+        local_last_updated_unit_value = self.mydict._local_last_updated
+
+        for case in [(False, False), (False, True), (True, False)]:
+            expired_mock.return_value, invalid_mock.return_value = case
+            self.mydict._populate()
+            self.assertEquals(self.mydict._local_last_updated,
+                              local_last_updated_unit_value)
+
+        expired_mock.return_value = True
+        invalid_mock.return_value = True
+        self.mydict._populate()
+        self.assertNotEquals(self.mydict._local_last_updated,
+                             local_last_updated_unit_value)

--- a/tests/modeldict/urls.py
+++ b/tests/modeldict/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url, include
 
 def dummy_view(request):
     from django.http import HttpResponse


### PR DESCRIPTION
PR based on https://github.com/disqus/django-modeldict/pull/7

Update _local_last_updated only after an actual update takes place.
In the case where updating from remote cache fails, fallback population
from source would trigger and update _local_last_update with correct data.

Motivation behind PR:
In Delivery Hero we are experiencing some weird gargoyle switches behavior. After changing the status of a feature switch about 50% of request would behave as if switch status did not change and the number of 'bad' request would slowly go down to 0. 'Bad cache' seems to be triggered and continuously observed only if there is significant server load. I verified that higher server load leads to faster flush of bad cache and linked it to the reload of uwsgi processes. I also verified that johnny-cache does not cause this, so I turned to gargoyle itself and found a possible bug in local cache implementation in modeldict.base.CachedDict. After some meditation, I saw that under constant load there is a chance that CachedDict would never mark its local cache as invalid. While the process(1) changing the switch status is executing _populate(reset=True), a _populate(reset=False) in another process would set self._local_last_updated = now and there is a chance that that now is > now in process 1.

Testing done on the changes:
We have not done testing in real environments.
For local testing, I would run a few django shells and run spammer (from https://github.com/lyudmildrx/django-modeldict/commit/7b3e0f57390e2acb76da08b4f2a4c2274e9d3c81) in each of them. I would then change the feature switch value and observe the running shells. Some of the shells would continue looping thinking that the feature switch status did not change.
With changes from PR, none of the shells continue looping.

Update:
At Delivery Hero we would use a managament command with the following code to flush bad cache out. We tested this on our live system and it worked as expected. The outcome of the command strongly suggests that the cause of the bad cache is bad local_last_updated value.

gargoyle.gargoyle._populate(reset=True)
future_time = int(time.time()) + 60  # Just have to be in the future
gargoyle.gargoyle.remote_cache.set(
    gargoyle.gargoyle.remote_cache_last_updated_key, future_time)
time.sleep(35)  # 30 is constant local cache timeout + 5 just in case
gargoyle.gargoyle._populate(reset=True)
