### PR TITLE
Update requirements and test scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,14 @@ python:
   - "2.6"
   - "2.7"
 env:
-  - DJANGO=1.2.7
-  - DJANGO=1.3.1
   - DJANGO=1.4
+  - DJANGO=1.5
+  - DJANGO=1.6
+  - DJANGO=1.7
+matrix:
+  exclude:
+    - python: "2.6"
+      env: DJANGO=1.7
 install:
   - pip install -q Django==$DJANGO --use-mirrors
   - pip install pep8 --use-mirrors

--- a/tests/modeldict/__init__.py
+++ b/tests/modeldict/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'tests.modeldict.apps.ModelDictTestsConfig'

--- a/tests/modeldict/apps.py
+++ b/tests/modeldict/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class ModelDictTestsConfig(AppConfig):
+    name = 'tests.modeldict'
+    label = 'modeldict-tests'

--- a/tests/modeldict/urls.py
+++ b/tests/modeldict/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url, include
 
 def dummy_view(request):
     from django.http import HttpResponse


### PR DESCRIPTION
Refresh django versions included in continuous integration.
Include changes needed for running tests with django 1.7

Note Python 2.6 support has been dropped for django 1.7
