### PR TITLE
Update handling of _last_checked_for_remote_changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,14 @@ python:
   - "2.6"
   - "2.7"
 env:
-  - DJANGO=1.2.7
-  - DJANGO=1.3.1
   - DJANGO=1.4
+  - DJANGO=1.5
+  - DJANGO=1.6
+  - DJANGO=1.7
+matrix:
+  exclude:
+    - python: "2.6"
+      env: DJANGO=1.7
 install:
   - pip install -q Django==$DJANGO --use-mirrors
   - pip install pep8 --use-mirrors

--- a/modeldict/base.py
+++ b/modeldict/base.py
@@ -183,12 +183,12 @@ class CachedDict(object):
                     # We've updated from remote, so mark ourselves as such
                     self._local_last_updated = now
 
+            # We just checked for remote changes
+            self._last_checked_for_remote_changes = now
+
         # Update from source if local_cache is still empty
         if self._local_cache is None:
             self._update_cache_data()
-
-        # No matter what happened, we last checked for remote changes just now
-        self._last_checked_for_remote_changes = now
 
         return self._local_cache
 

--- a/modeldict/base.py
+++ b/modeldict/base.py
@@ -179,12 +179,11 @@ class CachedDict(object):
             # local_cache
             if local_cache_is_invalid or local_cache_is_invalid is None:
                 self._local_cache = self.remote_cache.get(self.remote_cache_key)
+                if self._local_cache:
+                    # We've updated from remote, so mark ourselves as such
+                    self._local_last_updated = now
 
-            # No matter what, we've updated from remote, so mark ourselves as
-            # such so that we won't expire until the next timeout
-            self._local_last_updated = now
-
-        # Update from cache if local_cache is still empty
+        # Update from source if local_cache is still empty
         if self._local_cache is None:
             self._update_cache_data()
 

--- a/tests/modeldict/__init__.py
+++ b/tests/modeldict/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'tests.modeldict.apps.ModelDictTestsConfig'

--- a/tests/modeldict/apps.py
+++ b/tests/modeldict/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class ModelDictTestsConfig(AppConfig):
+    name = 'tests.modeldict'
+    label = 'modeldict-tests'

--- a/tests/modeldict/tests.py
+++ b/tests/modeldict/tests.py
@@ -338,3 +338,25 @@ class CachedDictTest(TestCase):
             self.mydict.remote_cache_last_updated_key
         )
         self.assertEquals(result, True)
+
+    @mock.patch('modeldict.base.CachedDict.local_cache_has_expired')
+    @mock.patch('modeldict.base.CachedDict.local_cache_is_invalid')
+    def test_local_last_updated_value(self, invalid_mock, expired_mock):
+        """
+        We want local cache last updated value to be updated if and only if
+        a cache update actually took place.
+        """
+        self.mydict._local_cache = {}
+        local_last_updated_unit_value = self.mydict._local_last_updated
+
+        for case in [(False, False), (False, True), (True, False)]:
+            expired_mock.return_value, invalid_mock.return_value = case
+            self.mydict._populate()
+            self.assertEquals(self.mydict._local_last_updated,
+                              local_last_updated_unit_value)
+
+        expired_mock.return_value = True
+        invalid_mock.return_value = True
+        self.mydict._populate()
+        self.assertNotEquals(self.mydict._local_last_updated,
+                             local_last_updated_unit_value)

--- a/tests/modeldict/urls.py
+++ b/tests/modeldict/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url, include
 
 def dummy_view(request):
     from django.http import HttpResponse


### PR DESCRIPTION
Based on https://github.com/disqus/django-modeldict/pull/6

Under constant load, the value would be be updated all the time and cache would never show as invalid, if ModelDict did not register a request finished signal handler that would call _cleanup and void the value of _last_checked_for_remote_changes.
