### PR TITLE
Add deprecation notice to point to the YPlan fork

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+------------------
+NOTICE: Deprecated
+------------------
+
+This project is deprecated and no longer actively maintained by `Disqus <https://disqus.com/>`_. However there is a fork being maintained by YPlan at `github.com/YPlan/django-modeldict <https://github.com/YPlan/django-modeldict>`_.
+
 ----------------
 django-modeldict
 ----------------


### PR DESCRIPTION
Our fork is compatible with Python 3 and the latest versions of Django, and available on PyPI as `django-modeldict-yplan`.